### PR TITLE
basic stuff for single, and double left click mouse support

### DIFF
--- a/include/outputs.h
+++ b/include/outputs.h
@@ -12,5 +12,9 @@ void deinit_outputs();
 // return the rate-of-change of the euler value against the previous euler value, in degrees/sec
 imu_euler_type get_euler_velocities(imu_euler_type euler);
 
+void singletap(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,
+                       bool imu_calibrated, ipc_values_type *ipc_values);
+void doubletap(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,
+                       bool imu_calibrated, ipc_values_type *ipc_values);
 void handle_imu_update(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,
                        bool imu_calibrated, ipc_values_type *ipc_values);

--- a/src/driver.c
+++ b/src/driver.c
@@ -34,15 +34,18 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define DEVICE_DRIVER_COUNT 2
+#define DEVICE_DRIVER_COUNT 2 
 const device_driver_type* device_drivers[DEVICE_DRIVER_COUNT] = {
     &xreal_driver,
     &viture_driver
 };
 
 #define EVENT_SIZE (sizeof(struct inotify_event) + NAME_MAX + 1)
-#define MT_RECENTER_SCREEN 2
-#define MT_RESET_CALIBRATION 3
+#define MT_SINGLE_CLICK 1
+#define MT_DOUBLE_CLICK 2
+#define MT_RECENTER_SCREEN 3
+#define MT_RESET_CALIBRATION 4
+
 
 driver_config_type *config() {
     return context.config;
@@ -86,7 +89,19 @@ void driver_handle_imu_event(uint32_t timestamp_ms, imu_quat_type quat, imu_eule
         int multi_tap = detect_multi_tap(euler_velocities,
                                          timestamp_ms,
                                          config()->debug_multi_tap);
-        if (multi_tap == MT_RESET_CALIBRATION || control_flags->recalibrate) {
+
+	if (multi_tap == MT_SINGLE_CLICK){
+		printf("Single Click detected...\n");
+		singletap(timestamp_ms, quat, euler_velocities, ipc_enabled, glasses_calibrated, ipc_values);	
+	}
+
+        if (multi_tap == MT_DOUBLE_CLICK){
+	printf("Double Click detected...\n");
+	doubletap(timestamp_ms, quat, euler_velocities, ipc_enabled, glasses_calibrated, ipc_values);
+	
+	}
+	
+	if (multi_tap == MT_RESET_CALIBRATION || control_flags->recalibrate) {
             if (multi_tap == MT_RESET_CALIBRATION) printf("Triple-tap detected. ");
             printf("Kicking off calibration\n");
             reset_calibration(true);

--- a/src/driver.c
+++ b/src/driver.c
@@ -91,14 +91,13 @@ void driver_handle_imu_event(uint32_t timestamp_ms, imu_quat_type quat, imu_eule
                                          config()->debug_multi_tap);
 
 	if (multi_tap == MT_SINGLE_CLICK){
-		printf("Single Click detected...\n");
-		singletap(timestamp_ms, quat, euler_velocities, ipc_enabled, glasses_calibrated, ipc_values);	
+            printf("Single Click detected...\n");
+            singletap(timestamp_ms, quat, euler_velocities, ipc_enabled, glasses_calibrated, ipc_values);	
 	}
 
         if (multi_tap == MT_DOUBLE_CLICK){
-	printf("Double Click detected...\n");
-	doubletap(timestamp_ms, quat, euler_velocities, ipc_enabled, glasses_calibrated, ipc_values);
-	
+            printf("Double Click detected...\n");
+            doubletap(timestamp_ms, quat, euler_velocities, ipc_enabled, glasses_calibrated, ipc_values);
 	}
 	
 	if (multi_tap == MT_RESET_CALIBRATION || control_flags->recalibrate) {

--- a/src/multitap.c
+++ b/src/multitap.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#define MT_BUFFER_MS 25
+#define MT_BUFFER_MS 15
 
 #define MT_STATE_IDLE 0
 #define MT_STATE_RISE 1
@@ -19,13 +19,13 @@ int imu_cycles_per_s;
 buffer_type *mt_buffer = NULL;
 int mt_state = MT_STATE_IDLE;
 const float mt_detect_threshold = 2000.0;
-const float mt_pause_threshold = 100.0;
+const float mt_pause_threshold = 1000.0;
 uint64_t tap_start_time = 0;
 uint64_t pause_start_time = 0;
 uint64_t last_logged_peak_time = 0;
-const int max_tap_period_ms = 750; // longest time-frame to allow between tap starts/rises
+const int max_tap_period_ms = 800; // longest time-frame to allow between tap starts/rises
 const int max_tap_duration_ms = 70; // a single tap should be very quick, ignore long accelerations
-const int min_pause_ms = 10; // must detect a pause (~0 acceleration) between taps
+const int min_pause_ms = 70; // must detect a pause (~0 acceleration) between taps
 float peak_max = 0.0;
 int tap_count = 0;
 
@@ -64,7 +64,7 @@ int detect_multi_tap(imu_euler_type velocities, uint32_t timestamp, bool debug) 
                 mt_state = MT_STATE_IDLE;
                 int final_tap_count = tap_count;
                 tap_count = 0;
-
+		printf("final_tap_count = %d\n",final_tap_count);
                 if (final_tap_count > 0 && debug) fprintf(stdout, "\tdebug: detected multi-tap of %d\n", final_tap_count);
                 return final_tap_count;
             } else {

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -225,6 +225,21 @@ void deinit_outputs() {
         evdev = NULL;
     }
 }
+void singletap(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,
+                       bool imu_calibrated, ipc_values_type *ipc_values) {
+libevdev_uinput_write_event(uinput, EV_KEY, BTN_LEFT,1);
+libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
+libevdev_uinput_write_event(uinput, EV_KEY, BTN_LEFT,0);
+libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
+}
+
+void doubletap(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,
+                       bool imu_calibrated, ipc_values_type *ipc_values) {
+libevdev_uinput_write_event(uinput, EV_KEY, BTN_RIGHT, 1);
+libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
+libevdev_uinput_write_event(uinput, EV_KEY, BTN_RIGHT, 0);
+libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
+}
 
 void handle_imu_update(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,
                        bool imu_calibrated, ipc_values_type *ipc_values) {

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -227,18 +227,16 @@ void deinit_outputs() {
 }
 void singletap(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,
                        bool imu_calibrated, ipc_values_type *ipc_values) {
-libevdev_uinput_write_event(uinput, EV_KEY, BTN_LEFT,1);
-libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
-libevdev_uinput_write_event(uinput, EV_KEY, BTN_LEFT,0);
-libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
+    libevdev_uinput_write_event(uinput, EV_KEY, BTN_LEFT,1);
+    libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
+    libevdev_uinput_write_event(uinput, EV_KEY, BTN_LEFT,0);
+    libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
 }
 
 void doubletap(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,
                        bool imu_calibrated, ipc_values_type *ipc_values) {
-libevdev_uinput_write_event(uinput, EV_KEY, BTN_RIGHT, 1);
-libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
-libevdev_uinput_write_event(uinput, EV_KEY, BTN_RIGHT, 0);
-libevdev_uinput_write_event(uinput, EV_SYN, SYN_REPORT, 0);
+    singletap(timestamp_ms, quat, velocities, ipc_enabled, imu_calibrated, ipc_values);
+    singletap(timestamp_ms, quat, velocities, ipc_enabled, imu_calibrated, ipc_values);
 }
 
 void handle_imu_update(uint32_t timestamp_ms, imu_quat_type quat, imu_euler_type velocities, bool ipc_enabled,


### PR DESCRIPTION
This is a first go of basic left mouse support with the driver.  By tapping on the side of the XReal Air, you can initiate a "tap" event.  This was already existing in wheaney's code.  

The updates with this PR move the following down in index and add a single left mouse click, and a double left mouse click:
Original:
#MT_RECENTER_SCREEN 2
#define MT_RESET_CALIBRATION 3

PR submission:
#define MT_SINGLE_CLICK 1
#define MT_DOUBLE_CLICK 2
#define MT_RECENTER_SCREEN 3
#define MT_RESET_CALIBRATION 4

There are additional changes to be made, and will come later, but this should help with basics.