### PR TITLE
Fix service for Fedora distros

### DIFF
--- a/systemd/xreal-air-driver.service
+++ b/systemd/xreal-air-driver.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Environment=HOME={user_home}
-ExecStart=/usr/bin/bash -c {user_home}/bin/xrealAirLinuxDriver
+ExecStart=/bin/bash -c {user_home}/bin/xrealAirLinuxDriver
 Restart=on-failure
 
 [Install]

--- a/systemd/xreal-air-driver.service
+++ b/systemd/xreal-air-driver.service
@@ -4,8 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Environment=HOME={user_home}
-ExecStart={user_home}/bin/xrealAirLinuxDriver
+ExecStart=env HOME={user_home} {user_home}/bin/xrealAirLinuxDriver
 Restart=on-failure
 
 [Install]

--- a/systemd/xreal-air-driver.service
+++ b/systemd/xreal-air-driver.service
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=env HOME={user_home} {user_home}/bin/xrealAirLinuxDriver
+Environment=HOME={user_home}
+ExecStart=/usr/bin/bash -c {user_home}/bin/xrealAirLinuxDriver
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Moving the environment variable into the `ExecStart` line seems to make this work on Fedora (specifically Bazzite).