### PR TITLE
nix: Add Nix Flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,0 +1,45 @@
+name: Nix CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Check flake
+        run: nix flake check --print-build-logs
+
+  build-packages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - xrlinuxdriver
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build ${{ matrix.package }}
+        run: nix build --print-build-logs ".#${{ matrix.package }}"

--- a/.github/workflows/nix-update-inputs.yml
+++ b/.github/workflows/nix-update-inputs.yml
@@ -1,0 +1,36 @@
+name: Nix - Update Inputs
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  update-inputs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Update inputs
+        run: nix flake update
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- flake.lock; then
+            echo "No changes to inputs"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add flake.lock
+          git commit -m "chore(flake): update inputs"
+          git push origin HEAD:main

--- a/.nix/XRLinuxDriver/default.nix
+++ b/.nix/XRLinuxDriver/default.nix
@@ -1,0 +1,180 @@
+{
+  # Core inputs
+  self,
+  lib,
+  pkgs,
+  stdenv,
+  autoPatchelfHook,
+  # xrDriver deps
+  libusb1,
+  curl,
+  openssl,
+  libevdev,
+  json_c,
+  hidapi,
+  wayland,
+  cmake,
+  pkg-config,
+  python3,
+  libffi,
+  systemd,
+  makeWrapper,
+  jq,
+  # nrealAirLinuxDriver deps
+  rustPlatform,
+  rustc,
+  cargo,
+  ...
+}:
+let
+  arch =
+    let
+      inherit (pkgs.stdenv.hostPlatform) isx86_64 isLinux isAarch64;
+    in
+    if isAarch64 && isLinux then
+      "aarch64"
+    else if isx86_64 && isLinux then
+      "x86_64"
+    else
+      throw "Unsupported system ${pkgs.stdenv.hostPlatform.system}";
+
+  version =
+    let
+      versionFile = pkgs.runCommand "xrlinuxdriver-version" { } ''
+        grep -oP '(?<=project\(xrDriver VERSION )[0-9]+\.[0-9]+\.[0-9]+' ${self}/CMakeLists.txt > $out
+      '';
+    in
+    lib.strings.trim (builtins.readFile versionFile);
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xrlinuxdriver";
+  inherit version;
+
+  src = lib.cleanSourceWith {
+    src = self;
+    name = "${finalAttrs.pname}-src";
+  };
+
+  cargoRoot = "modules/xrealOneDeviceKit/modules/xreal_one_driver";
+
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = "${finalAttrs.src}/${finalAttrs.cargoRoot}/Cargo.lock";
+  };
+
+  nativeBuildInputs =
+    let
+      pythonEnv = python3.withPackages (ps: [ ps.pyyaml ]);
+    in
+    [
+      cmake
+      pkg-config
+      pythonEnv
+      autoPatchelfHook
+      rustPlatform.cargoSetupHook
+      rustc
+      cargo
+      makeWrapper
+    ];
+  buildInputs = [
+    curl
+    hidapi
+    json_c
+    libevdev
+    libffi
+    libusb1
+    openssl
+    systemd
+    wayland
+  ];
+
+  # The vendor .so blobs and hidapi-hidraw need libudev at link time
+  NIX_LDFLAGS = "-ludev";
+
+  autoPatchelfIgnoreMissingDeps = [ "libopencv_*" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Main binary
+    install -Dm755 xrDriver $out/bin/xrDriver
+
+    # Vendor SDK shared libraries. CMake auto-detects these at build time
+    # by presence under lib/${arch}, so the install step mirrors that: it
+    # only installs what actually exists for this arch, since not every
+    # SDK ships blobs for every arch (e.g. RayNeo/Rokid are x86_64-only
+    # upstream, VITURE ships for both x86_64 and aarch64).
+    mkdir -p $out/lib
+
+    # RayNeo XR Mini SDK
+    if [ -f "$src/lib/${arch}/libRayNeoXRMiniSDK.so" ]; then
+      install -Dm755 "$src/lib/${arch}/libRayNeoXRMiniSDK.so" $out/lib/libRayNeoXRMiniSDK.so
+    fi
+
+    # Rokid Glass SDK
+    if [ -f "$src/lib/${arch}/libGlassSDK.so" ]; then
+      install -Dm755 "$src/lib/${arch}/libGlassSDK.so" $out/lib/libGlassSDK.so
+    fi
+
+    # VITURE SDK, plus its bundled OpenCV/libcarina_vio dependencies.
+    # These are versioned shared objects with .so -> .so.X.Y symlink
+    # chains, so copy with -d to preserve links instead of flattening
+    # them into duplicate files via `install`.
+    if [ -d "$src/lib/${arch}/viture" ]; then
+      cp -dR "$src/lib/${arch}/viture/"*.so* $out/lib/
+      find $out/lib -maxdepth 1 -type f -exec chmod 755 {} +
+    fi
+
+    # Install hidapi shared libs built during CMake
+    find . -name 'libhidapi*.so*' \( -type f -o -type l \) | while read -r f; do
+      cp -a "$f" $out/lib/
+    done
+
+    patchelf --set-rpath "$out/lib:${
+      lib.makeLibraryPath [
+        systemd
+        stdenv.cc.cc.lib
+        curl
+        openssl
+        json_c
+        libusb1
+        libevdev
+        wayland
+      ]
+    }" $out/bin/xrDriver
+
+    # CLI tool
+    install -Dm755 $src/bin/xr_driver_cli $out/bin/xr_driver_cli
+    wrapProgram $out/bin/xr_driver_cli \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          jq
+          curl
+        ]
+      }
+
+    # Udev rules
+    mkdir -p $out/lib/udev/rules.d
+    cp $src/udev/*.rules $out/lib/udev/rules.d
+
+    # Systemd user service
+    install -Dm644 $src/systemd/xr-driver.service $out/lib/systemd/user/xr-driver.service
+    substituteInPlace $out/lib/systemd/user/xr-driver.service \
+      --replace-fail '{ld_library_path}' "$out/lib" \
+      --replace-fail '{bin_dir}' "$out/bin"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = false;
+  # The default release is a script which will do an impure download
+  # just ensure that the application can run without network
+
+  meta = {
+    homepage = "https://github.com/wheaney/XRLinuxDriver";
+    license = lib.licenses.mit;
+    description = "Linux service for interacting with XR devices.";
+    mainProgram = "xrDriver";
+    maintainers = with lib.maintainers; [ shymega ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ pkg_check_modules(LIBWAYLAND_CLIENT REQUIRED wayland-client)
 
 execute_process(COMMAND git submodule update --init --recursive
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_subdirectory(modules/xrealInterfaceLibrary/interface_lib)
 
 # Set the library directory based on architecture

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+) {src = ./.;}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1789149629,
+        "narHash": "sha256-H6GwaZzZf+4npqv0tph94w9tZddSjFjmQrVsW0z78uk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eaad089433ca2bb662274377d33df3d0e51ef28b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Nix Flake for XRLinuxDriver";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    self.submodules = true;
+  };
+  outputs = inputs: let
+    inherit (inputs) self nixpkgs;
+
+    forEachSystem = let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      genPkgs = system: nixpkgs.legacyPackages.${system};
+      inherit (nixpkgs.lib) genAttrs;
+    in
+      f: genAttrs systems (system: f (genPkgs system));
+  in {
+    packages = forEachSystem (pkgs: {
+      xrlinuxdriver = pkgs.callPackage ./package.nix {inherit self;};
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.xrlinuxdriver;
+    });
+
+    devShells = forEachSystem (pkgs: {
+      default = pkgs.mkShell {
+        inputsFrom = pkgs.lib.singleton self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      };
+    });
+
+    overlays.default = _: prev: self.packages.${prev.stdenv.hostPlatform.system};
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Nix Flake for XRLinuxDriver";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    self.submodules = true;
+  };
+  outputs =
+    inputs:
+    let
+      inherit (inputs) self nixpkgs;
+
+      forEachSystem =
+        let
+          systems = [
+            "x86_64-linux"
+            "aarch64-linux"
+          ];
+          genPkgs = system: nixpkgs.legacyPackages.${system};
+          inherit (nixpkgs.lib) genAttrs;
+        in
+        f: genAttrs systems (system: f (genPkgs system));
+    in
+    {
+      packages = forEachSystem (pkgs: {
+        xrlinuxdriver = pkgs.callPackage ./package.nix { inherit self; };
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.xrlinuxdriver;
+      });
+
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.mkShell {
+          inputsFrom = pkgs.lib.singleton self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
+      });
+
+      overlays.default = _: prev: self.packages.${prev.stdenv.hostPlatform.system};
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Nix Flake for XRLinuxDriver";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    self.submodules = true;
+  };
+  outputs =
+    inputs:
+    let
+      inherit (inputs) self nixpkgs;
+
+      forEachSystem =
+        let
+          systems = [
+            "x86_64-linux"
+            "aarch64-linux"
+          ];
+          genPkgs = system: nixpkgs.legacyPackages.${system};
+          inherit (nixpkgs.lib) genAttrs;
+        in
+        f: genAttrs systems (system: f (genPkgs system));
+    in
+    {
+      packages = forEachSystem (pkgs: {
+        xrlinuxdriver = pkgs.callPackage ./.nix/XRLinuxDriver { inherit self; };
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.xrlinuxdriver;
+      });
+
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.mkShell {
+          inputsFrom = pkgs.lib.singleton self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
+      });
+
+      overlays.default = _: prev: self.packages.${prev.stdenv.hostPlatform.system} or {};
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,157 @@
+{
+  # Core inputs
+  self,
+  lib,
+  pkgs,
+  stdenv,
+  autoPatchelfHook,
+  # xrDriver deps
+  libusb1,
+  curl,
+  openssl,
+  libevdev,
+  json_c,
+  hidapi,
+  wayland,
+  cmake,
+  pkg-config,
+  python3,
+  libffi,
+  systemd,
+  makeWrapper,
+  jq,
+  # nrealAirLinuxDriver deps
+  rustPlatform,
+  rustc,
+  cargo,
+  ...
+}:
+let
+  arch =
+    let
+      inherit (pkgs.stdenv.hostPlatform) isx86_64 isLinux isAarch64;
+    in
+    if isAarch64 && isLinux then
+      "aarch64"
+    else if isx86_64 && isLinux then
+      "x86_64"
+    else
+      throw "Unsupported system ${pkgs.stdenv.hostPlatform.system}";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xrlinuxdriver";
+  version = "2.0.5";
+
+  src = lib.cleanSourceWith {
+    src = self;
+    name = "${finalAttrs.pname}-src";
+  };
+
+  cargoRoot = "modules/xrealInterfaceLibrary/interface_lib/modules/xreal_one_driver";
+
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = "${finalAttrs.src}/${finalAttrs.cargoRoot}/Cargo.lock";
+  };
+
+  nativeBuildInputs =
+    let
+      pythonEnv = python3.withPackages (ps: [ ps.pyyaml ]);
+    in
+    [
+      cmake
+      pkg-config
+      pythonEnv
+      autoPatchelfHook
+      rustPlatform.cargoSetupHook
+      rustc
+      cargo
+      makeWrapper
+    ];
+  buildInputs = [
+    curl
+    hidapi
+    json_c
+    libevdev
+    libffi
+    libusb1
+    openssl
+    systemd
+    wayland
+  ];
+
+  # The vendor .so blobs and hidapi-hidraw need libudev at link time
+  NIX_LDFLAGS = "-ludev";
+
+  autoPatchelfIgnoreMissingDeps = [ "libopencv_*" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Main binary
+    install -Dm755 xrDriver $out/bin/xrDriver
+
+    # Vendor SDK shared libraries
+    mkdir -p $out/lib
+    for so in $src/lib/${arch}/*.so; do
+      [ -f "$so" ] && install -Dm755 "$so" $out/lib/$(basename "$so")
+    done
+    if [ -d "$src/lib/${arch}/viture" ]; then
+      for so in $src/lib/${arch}/viture/*.so*; do
+        [ -f "$so" ] && install -Dm755 "$so" $out/lib/$(basename "$so")
+      done
+    fi
+
+    # Install hidapi shared libs built during CMake
+    find . -name 'libhidapi*.so*' \( -type f -o -type l \) | while read -r f; do
+      cp -a "$f" $out/lib/
+    done
+
+    patchelf --set-rpath "$out/lib:${
+      lib.makeLibraryPath [
+        systemd
+        stdenv.cc.cc.lib
+        curl
+        openssl
+        json_c
+        libusb1
+        libevdev
+        wayland
+      ]
+    }" $out/bin/xrDriver
+
+    # CLI tool
+    install -Dm755 $src/bin/xr_driver_cli $out/bin/xr_driver_cli
+    wrapProgram $out/bin/xr_driver_cli \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          jq
+          curl
+        ]
+      }
+
+    # Udev rules
+    mkdir -p $out/lib/udev/rules.d
+    cp $src/udev/*.rules $out/lib/udev/rules.d
+
+    # Systemd user service
+    install -Dm644 $src/systemd/xr-driver.service $out/lib/systemd/user/xr-driver.service
+    substituteInPlace $out/lib/systemd/user/xr-driver.service \
+      --replace-fail '{ld_library_path}' "$out/lib" \
+      --replace-fail '{bin_dir}' "$out/bin"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = false;
+  # The default release is a script which will do an impure download
+  # just ensure that the application can run without network
+
+  meta = {
+    homepage = "https://github.com/wheaney/XRLinuxDriver";
+    license = lib.licenses.mit;
+    description = "Linux service for interacting with XR devices.";
+    mainProgram = "xrDriver";
+    maintainers = with lib.maintainers; [ shymega ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,180 @@
+{
+  # Core inputs
+  self,
+  lib,
+  pkgs,
+  stdenv,
+  autoPatchelfHook,
+  # xrDriver deps
+  libusb1,
+  curl,
+  openssl,
+  libevdev,
+  json_c,
+  hidapi,
+  wayland,
+  cmake,
+  pkg-config,
+  python3,
+  libffi,
+  systemd,
+  makeWrapper,
+  jq,
+  # nrealAirLinuxDriver deps
+  rustPlatform,
+  rustc,
+  cargo,
+  ...
+}:
+let
+  arch =
+    let
+      inherit (pkgs.stdenv.hostPlatform) isx86_64 isLinux isAarch64;
+    in
+    if isAarch64 && isLinux then
+      "aarch64"
+    else if isx86_64 && isLinux then
+      "x86_64"
+    else
+      throw "Unsupported system ${pkgs.stdenv.hostPlatform.system}";
+
+  version =
+    let
+      versionFile = pkgs.runCommand "xrlinuxdriver-version" { } ''
+        grep -oP '(?<=project\(xrDriver VERSION )[0-9]+\.[0-9]+\.[0-9]+' ${self}/CMakeLists.txt > $out
+      '';
+    in
+    lib.strings.trim (builtins.readFile versionFile);
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xrlinuxdriver";
+  inherit version;
+
+  src = lib.cleanSourceWith {
+    src = self;
+    name = "${finalAttrs.pname}-src";
+  };
+
+  cargoRoot = "modules/xrealOneDeviceKit/modules/xreal_one_driver";
+
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = "${finalAttrs.src}/${finalAttrs.cargoRoot}/Cargo.lock";
+  };
+
+  nativeBuildInputs =
+    let
+      pythonEnv = python3.withPackages (ps: [ ps.pyyaml ]);
+    in
+    [
+      cmake
+      pkg-config
+      pythonEnv
+      autoPatchelfHook
+      rustPlatform.cargoSetupHook
+      rustc
+      cargo
+      makeWrapper
+    ];
+  buildInputs = [
+    curl
+    hidapi
+    json_c
+    libevdev
+    libffi
+    libusb1
+    openssl
+    systemd
+    wayland
+  ];
+
+  # The vendor .so blobs and hidapi-hidraw need libudev at link time
+  NIX_LDFLAGS = "-ludev";
+
+  autoPatchelfIgnoreMissingDeps = [ "libopencv_*" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Main binary
+    install -Dm755 xrDriver $out/bin/xrDriver
+
+    # Vendor SDK shared libraries. CMake auto-detects these at build time
+    # by presence under lib/${arch}, so the install step mirrors that: it
+    # only installs what actually exists for this arch, since not every
+    # SDK ships blobs for every arch (e.g. RayNeo/Rokid are x86_64-only
+    # upstream, VITURE ships for both x86_64 and aarch64).
+    mkdir -p $out/lib
+
+    # RayNeo XR Mini SDK
+    if [ -f "$src/lib/${arch}/libRayNeoXRMiniSDK.so" ]; then
+      install -Dm755 "$src/lib/${arch}/libRayNeoXRMiniSDK.so" $out/lib/libRayNeoXRMiniSDK.so
+    fi
+
+    # Rokid Glass SDK
+    if [ -f "$src/lib/${arch}/libGlassSDK.so" ]; then
+      install -Dm755 "$src/lib/${arch}/libGlassSDK.so" $out/lib/libGlassSDK.so
+    fi
+
+    # VITURE SDK, plus its bundled OpenCV/libcarina_vio dependencies.
+    # These are versioned shared objects with .so -> .so.X.Y symlink
+    # chains, so copy with -d to preserve links instead of flattening
+    # them into duplicate files via `install`.
+    if [ -d "$src/lib/${arch}/viture" ]; then
+      cp -dR "$src/lib/${arch}/viture/"*.so* $out/lib/
+      find $out/lib -maxdepth 1 -type f -exec chmod 755 {} +
+    fi
+
+    # Install hidapi shared libs built during CMake
+    find . -name 'libhidapi*.so*' \( -type f -o -type l \) | while read -r f; do
+      cp -a "$f" $out/lib/
+    done
+
+    patchelf --set-rpath "$out/lib:${
+      lib.makeLibraryPath [
+        systemd
+        stdenv.cc.cc.lib
+        curl
+        openssl
+        json_c
+        libusb1
+        libevdev
+        wayland
+      ]
+    }" $out/bin/xrDriver
+
+    # CLI tool
+    install -Dm755 $src/bin/xr_driver_cli $out/bin/xr_driver_cli
+    wrapProgram $out/bin/xr_driver_cli \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          jq
+          curl
+        ]
+      }
+
+    # Udev rules
+    mkdir -p $out/lib/udev/rules.d
+    cp $src/udev/*.rules $out/lib/udev/rules.d
+
+    # Systemd user service
+    install -Dm644 $src/systemd/xr-driver.service $out/lib/systemd/user/xr-driver.service
+    substituteInPlace $out/lib/systemd/user/xr-driver.service \
+      --replace-fail '{ld_library_path}' "$out/lib" \
+      --replace-fail '{bin_dir}' "$out/bin"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = false;
+  # The default release is a script which will do an impure download
+  # just ensure that the application can run without network
+
+  meta = {
+    homepage = "https://github.com/wheaney/XRLinuxDriver";
+    license = lib.licenses.mit;
+    description = "Linux service for interacting with XR devices.";
+    mainProgram = "xrDriver";
+    maintainers = with lib.maintainers; [ shymega ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023 Dom Rodriguez <shymega@shymega.org.uk>
+#
+# SPDX-License-Identifier: GPL-3.0-only
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).shellNix

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023 Dom Rodriguez <shymega@shymega.org.uk>
+#
+# SPDX-License-Identifier: GPL-3.0-only
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+) {src = ./.;}).shellNix


### PR DESCRIPTION
This commit consists of the following changes:

- `default.nix`/`shell.nix`
  This allows for legacy Nix tooling like `nix-build`/`nix-shell` to work.
- `flake.nix`
  This is for the (new) Nix Flake support.
- `flake.lock`
  As above, but for tracking Flake inputs.
- `.envrc`
  This allows for a fully self-contained developer environment to be
  setup with Nix.
- `nix/default.nix`
  This is the main package derivation. Both this repo & Nixpkgs are
  derived from the same codebase.

Closes: #38