### PR TITLE
Update setup to fix domain joined accounts

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -30,7 +30,7 @@ To enable this, install the appropriate library. It's typically provided by the 
 fi
 
 USER=${SUDO_USER:-$USER}
-GROUP=$(id -gn $USER)
+GROUP=$(id -g $USER)
 USER_HOME=$(getent passwd $USER | cut -d: -f6)
 
 function create_and_chown() {


### PR DESCRIPTION
Removed -n flag from id command to use group number instead of group name. This fixes issues with groups imported from AD that have a space in the name.

Tested on Mint and Ubuntu. 