### PR TITLE
Add additional center position names

### DIFF
--- a/bin/xr_driver_cli
+++ b/bin/xr_driver_cli
@@ -168,7 +168,7 @@ Options:
     -bd, --breezy-desktop
     --opentrack-app
     -sv, --sideview
-    -svp, --sideview-position [top_left|top_right|bottom_left|bottom_right]
+    -svp, --sideview-position [top_left|top_right|bottom_left|bottom_right|middle_center|middle_left|top_center|middle_right|bottom_center]
     --smooth-follow, --no-smooth-follow
     -sft, --smooth-follow-threshold [threshold_value]
     --curved-display, --no-curved-display

--- a/src/plugins/sideview.c
+++ b/src/plugins/sideview.c
@@ -16,11 +16,11 @@ const char *sideview_position_names[SIDEVIEW_POSITION_COUNT] = {
     "top_right",
     "bottom_left",
     "bottom_right",
-    "center",
-	"center_left",
-    "center_top",
-    "center_right",
-    "center_bottom"
+    "middle_center",
+	"middle_left",
+    "top_center",
+    "middle_right",
+    "bottom_center"
 };
 
 sideview_config *sv_config;

--- a/src/plugins/sideview.c
+++ b/src/plugins/sideview.c
@@ -16,7 +16,11 @@ const char *sideview_position_names[SIDEVIEW_POSITION_COUNT] = {
     "top_right",
     "bottom_left",
     "bottom_right",
-    "center"
+    "center",
+	"center_left",
+    "center_top",
+    "center_right",
+    "center_bottom"
 };
 
 sideview_config *sv_config;


### PR DESCRIPTION
Extend sideview_position_names with four new center-aligned entries: center_left, center_top, center_right, and center_bottom. This enables finer-grained center positioning for the sideview plugin (ensure SIDEVIEW_POSITION_COUNT is updated accordingly where needed).